### PR TITLE
Support Fluentd v0.14.12, v0.14.13, v0.14.14

### DIFF
--- a/lib/fluent/plugin/in_groonga.rb
+++ b/lib/fluent/plugin/in_groonga.rb
@@ -35,7 +35,7 @@ module Fluent
       super
     end
 
-    config_param :protocol, :defalut => :http do |value|
+    config_param :protocol, :default => :http do |value|
       case value
       when "http", "gqtp"
         value.to_sym

--- a/lib/fluent/plugin/in_groonga.rb
+++ b/lib/fluent/plugin/in_groonga.rb
@@ -141,7 +141,7 @@ module Fluent
 
       def start
         listen_socket = TCPServer.new(@bind, @port)
-        detach_multi_process do
+        block = lambda do
           @loop = Coolio::Loop.new
 
           @socket = Coolio::TCPServer.new(listen_socket, nil,
@@ -154,6 +154,12 @@ module Fluent
           @thread = Thread.new do
             run
           end
+        end
+        if respond_to?(:detach_multi_process)
+          $log.warn("[input][groonga][warn] detach_multi_process is not supported in this Fluentd version. ignored.")
+          detach_multi_process(&block)
+        else
+          block.call
         end
       end
 


### PR DESCRIPTION
* v0.14.12: Do not have DetachMultiProcess module and fluent/process
  library
* v0.14.13, v0.14.14: Do not have DetachMultiProcess#detach_process