### PR TITLE
Use enum instead of config_param with block

### DIFF
--- a/lib/fluent/plugin/in_groonga.rb
+++ b/lib/fluent/plugin/in_groonga.rb
@@ -35,14 +35,7 @@ module Fluent
       super
     end
 
-    config_param :protocol, :defalut => :http do |value|
-      case value
-      when "http", "gqtp"
-        value.to_sym
-      else
-        raise ConfigError, "must be http or gqtp: <#{value}>"
-      end
-    end
+    config_param :protocol, :enum, :list => [:http, :gqtp], :default => :http
 
     def configure(conf)
       super

--- a/lib/fluent/plugin/out_groonga.rb
+++ b/lib/fluent/plugin/out_groonga.rb
@@ -29,14 +29,7 @@ module Fluent
       super
     end
 
-    config_param :protocol, :default => :http do |value|
-      case value
-      when "http", "gqtp", "command"
-        value.to_sym
-      else
-        raise ConfigError, "must be http, gqtp or command: <#{value}>"
-      end
-    end
+    config_param :protocol, :enum, :list => [:http, :gqtp, :command], :default => :http
 
     # alias is just for backward compatibility
     config_param :store_table, :string, :default => nil, :alias => :table


### PR DESCRIPTION
This change breaks backward compatibility with Fluentd v0.10.x.
But Fluentd v0.10.x has reached EOL already.