### PR TITLE
test: use event_time helper for v0.14

### DIFF
--- a/test/test_input.rb
+++ b/test/test_input.rb
@@ -22,15 +22,18 @@ require "webrick/config"
 require "webrick/httpresponse"
 
 require "fluent/test"
+require "fluent/test/helpers"
 require "fluent/plugin/in_groonga"
 
 require "http_parser"
 
 class GroongaInputTest < Test::Unit::TestCase
+  include Fluent::Test::Helpers
+
   setup :before => :append
   def setup_fluent
     Fluent::Test.setup
-    @now = Time.parse("2012-10-26T08:45:42Z").to_i
+    @now = event_time("2012-10-26T08:45:42Z")
     Fluent::Engine.now = @now
   end
 

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -22,11 +22,14 @@ require "webrick/config"
 require "webrick/httpresponse"
 
 require "fluent/test"
+require "fluent/test/helpers"
 require "fluent/plugin/out_groonga"
 
 require "http_parser"
 
 class GroongaOutputTest < Test::Unit::TestCase
+  include Fluent::Test::Helpers
+
   setup :before => :append
   def setup_fluent
     Fluent::Test.setup
@@ -99,7 +102,7 @@ EOC
       def test_basic_command
         @response_body = JSON.generate([[0, 0.0, 0.0], true])
         driver = create_driver("groonga.command.table_create")
-        time = Time.parse("2012-10-26T08:45:42Z").to_i
+        time = event_time("2012-10-26T08:45:42Z")
         driver.emit({"name" => "Users"}, time)
         driver.run
         assert_equal("/d/table_create?name=Users",
@@ -118,7 +121,7 @@ EOC
       def test_one_message
         @response_body = JSON.generate([[0, 0.0, 0.0], [1]])
         driver = create_driver("log")
-        time = Time.parse("2012-10-26T08:45:42Z").to_i
+        time = event_time("2012-10-26T08:45:42Z")
         driver.emit({"message" => "1st message"}, time)
         driver.run
         assert_equal("/d/load?table=Logs",
@@ -130,7 +133,7 @@ EOC
       def test_multiple_messages
         @response_body = JSON.generate([[0, 0.0, 0.0], [2]])
         driver = create_driver("log")
-        time = Time.parse("2012-10-26T08:45:42Z").to_i
+        time = event_time("2012-10-26T08:45:42Z")
         driver.emit({"message" => "1st message"}, time)
         driver.emit({"message" => "2nd message"}, time + 1)
         driver.run
@@ -230,7 +233,7 @@ EOC
     class CommandTest < self
       def test_basic_command
         driver = create_driver("groonga.command.table_create")
-        time = Time.parse("2012-10-26T08:45:42Z").to_i
+        time = event_time("2012-10-26T08:45:42Z")
         driver.emit({"name" => "Users"}, time)
         driver.run
         assert_equal([


### PR DESCRIPTION
TODO: need feedback to fluentd because Fluent::Test::InputTestDriver
doesn't include Fluent::Test::Helpers to use assert_equal_event_time.