### PR TITLE
out: use more rubyish method

### DIFF
--- a/lib/fluent/plugin/out_groonga.rb
+++ b/lib/fluent/plugin/out_groonga.rb
@@ -113,7 +113,7 @@ module Fluent
         [tag, time, record].to_msgpack
       end
 
-      def formatted_to_msgpack_binary
+      def formatted_to_msgpack_binary?
         true
       end
 


### PR DESCRIPTION
before:

  formatted_to_msgpack_binary

after:

  formatted_to_msgpack_binary?

See http://www.fluentd.org/blog/fluentd-v0.14.15-has-been-released
blog entry why this method is introduced.