### PR TITLE
Add new command format

### DIFF
--- a/lib/fluent/plugin/in_groonga.rb
+++ b/lib/fluent/plugin/in_groonga.rb
@@ -36,6 +36,7 @@ module Fluent
       end
 
       config_param :protocol, :enum, :list => [:http, :gqtp], :default => :http
+      config_param :command_format, :enum, :list => [:tag, :record], :default => :tag
 
       def configure(conf)
         super
@@ -157,9 +158,20 @@ module Fluent
         def emit(command, params)
           normalized_command = command.split(".")[0]
           return unless emit_command?(normalized_command)
-          @input_plugin.router.emit("groonga.command.#{normalized_command}",
+          case @input_plugin.command_format
+              when :tag
+                 tag = "groonga.command.#{normalized_command}"
+                 record = params
+              else
+                 tag = "groonga.command"
+                 record = {
+                   "name" => normalized_command,
+                   "arguments" => params
+                 }
+              end
+          @input_plugin.router.emit(tag,
                                     Engine.now,
-                                    params)
+                                    record)
         end
 
         def log

--- a/lib/fluent/plugin/out_groonga.rb
+++ b/lib/fluent/plugin/out_groonga.rb
@@ -586,6 +586,10 @@ module Fluent
                 records.clear
               end
               @client.execute(name, record)
+            elsif tag == "groonga.command"
+              name = record["name"]
+              arguments = record["arguments"]
+              @client.execute(name, arguments)
             else
               records << record
             end

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -102,6 +102,17 @@ EOC
         assert_equal("/d/table_create?name=Users",
                      @request_parser.request_url)
       end
+
+      def test_basic_command_with_command_format_record
+        @response_body = JSON.generate([[0, 0.0, 0.0], true])
+        driver = create_driver
+        time = event_time("2012-10-26T08:45:42Z")
+        driver.run(default_tag: "groonga.command") do
+          driver.feed(time, {"name" => "table_create", "arguments" => {"name" => "Users"}})
+        end
+        assert_equal("/d/table_create?name=Users",
+                     @request_parser.request_url)
+      end
     end
 
     class StoreTest < self
@@ -232,6 +243,25 @@ EOC
         time = event_time("2012-10-26T08:45:42Z")
         driver.run(default_tag: "groonga.command.table_create") do
           driver.feed(time, {"name" => "Users"})
+        end
+        assert_equal([
+                       [
+                         "--input-fd", actual_input_fd,
+                         "--output-fd", actual_output_fd,
+                         "-n", @database_path,
+                       ],
+                       "/d/table_create?name=Users\n",
+                     ],
+                     [
+                       actual_command_line,
+                       actual_input,
+                     ])
+      end
+      def test_basic_command_with_command_format_record
+        driver = create_driver
+        time = event_time("2012-10-26T08:45:42Z")
+        driver.run(default_tag: "groonga.command") do
+          driver.feed(time, {"name" => "table_create", "arguments" => {"name" => "Users"}})
         end
         assert_equal([
                        [


### PR DESCRIPTION
Add new config option "command_format".
This config option change of output command format.
value of command_format options be.
 * tag(default) : dynamic tag
 * record : fixed tag

By setting tag fixedly, it prevents the order of commands from changing.