### PR TITLE
Fix supported Fluentd version for Fluentd v0.12.x

### DIFF
--- a/fluent-plugin-groonga.gemspec
+++ b/fluent-plugin-groonga.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.test_files += Dir.glob("test/**/*")
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency("fluentd")
+  spec.add_runtime_dependency("fluentd", ">= 0.12.10", "< 0.14.0")
   spec.add_runtime_dependency("groonga-client", ">= 0.1.0")
   spec.add_runtime_dependency("groonga-command-parser")
 

--- a/fluent-plugin-groonga.gemspec
+++ b/fluent-plugin-groonga.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.test_files += Dir.glob("test/**/*")
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency("fluentd", ">= 0.12.10", "< 0.14.0")
+  spec.add_runtime_dependency("fluentd", ">= 0.12.20", "< 0.14.0")
   spec.add_runtime_dependency("groonga-client", ">= 0.1.0")
   spec.add_runtime_dependency("groonga-command-parser")
 


### PR DESCRIPTION
I think nobody uses Fluentd v0.12.9 or earlier,
because Fluentd v0.12.10 has been released on 2015-05-28.

This change will make CI green.