### PR TITLE
Replace yajl-ruby with the json gem for JSON handling

### DIFF
--- a/lib/fluent/plugin/in_groonga.rb
+++ b/lib/fluent/plugin/in_groonga.rb
@@ -461,7 +461,7 @@ module Fluent
             @command_parser.on_load_value do |command, value|
               arguments = command.arguments.dup
               arguments[:columns] = command.columns.join(", ")
-              arguments[:values] = Yajl::Encoder.encode([value])
+              arguments[:values] = JSON.generate([value])
               @input.emit(command.command_name, arguments)
             end
           end

--- a/lib/fluent/plugin/out_groonga.rb
+++ b/lib/fluent/plugin/out_groonga.rb
@@ -16,7 +16,7 @@
 
 require "fileutils"
 
-require "yajl"
+require "json"
 
 require "groonga/client"
 
@@ -620,7 +620,7 @@ module Fluent
 
           arguments = {
             "table" => @table,
-            "values" => Yajl::Encoder.encode(records),
+            "values" => JSON.generate(records),
           }
           @client.execute("load", arguments)
         end


### PR DESCRIPTION
This commit replaces the `yajl-ruby` dependency with Ruby's standard `json` gem for the following reasons:

1. Future Compatibility: `yajl-ruby` is no longer actively maintained and relies on internal C APIs that are removed in Ruby 4.1. Migrating to the standard `json` gem ensures the plugin can continue to be built and used in future Ruby environments. Ref. https://github.com/ruby/ruby/pull/15447, https://github.com/brianmario/yajl-ruby/issues/233
2. Performance: The standard `json` gem has seen significant improvements in recent updates and now outperforms `yajl-ruby`.

```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
  gem 'yajl-ruby', require: 'yajl'
  gem 'json'
end

Benchmark.ips do |x|
  json = '{"a":"Alpha","b":true,"c":12345,"d":[true,[false,[-123456789,null],3.9676,["Something else.",false],null]],"e":{"zero":null,"one":1,"two":2,"three":[3],"four":[0,1,2,3,4]},"f":null,"h":{"a":{"b":{"c":{"d":{"e":{"f":{"g":null}}}}}}},"i":[[[[[[[null]]]]]]]}'

  x.report('Yajl.load') {
    Yajl.load(json)
  }
  x.report('JSON.parse') {
    JSON.parse(json)
  }

  x.compare!
end
```

```
ruby 4.0.5 (2026-05-20 revision 64336ffd0e) +PRISM [x86_64-linux]
Warming up --------------------------------------
           Yajl.load    20.019k i/100ms
          JSON.parse    80.144k i/100ms
Calculating -------------------------------------
           Yajl.load    202.875k (± 0.2%) i/s    (4.93 μs/i) -      1.021M in   5.032515s
          JSON.parse    808.103k (± 0.2%) i/s    (1.24 μs/i) -      4.087M in   5.057949s

Comparison:
JSON.parse:   808103.0 i/s
 Yajl.load:   202874.5 i/s - 3.98x  slower
```